### PR TITLE
DEVOPS-2138 create control-plane workloads

### DIFF
--- a/environments/default/addons/argo-cd/values.yaml
+++ b/environments/default/addons/argo-cd/values.yaml
@@ -103,6 +103,7 @@ configs:
       g, Provi-Engineering:DevOps, role:admin
 
   cm:
+    accounts.ci: apiKey
     application.resourceTrackingMethod: 'annotation' #use annotation for tracking required for Crossplane
     resource.exclusions: |
       - kinds:


### PR DESCRIPTION
This adds the control plane addons for the 1.29 cluster to ArgoCD,
including customization of the ArgoCD app itself (post bootstrap, it
will configure itself).