### PR TITLE
DEVOPS-2216 Make ArgoCD Internal

### DIFF
--- a/environments/default/addons/argo-cd/values.yaml
+++ b/environments/default/addons/argo-cd/values.yaml
@@ -54,7 +54,7 @@ server:
     type: LoadBalancer
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
-      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+      service.beta.kubernetes.io/aws-load-balancer-scheme: internal
 
 configs:
   repositories:


### PR DESCRIPTION
We are using `kubectl port-forward` to access ArgoCD within CircleCI, so we shouldn't need to make ArgoCD `internet-facing`.