### PR TITLE
DEVOPS-2418 cronitor addon

### DIFF
--- a/bootstrap/control-plane/addons/oss/addons-cronitor-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-cronitor-appset.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: addons-cronitor
+spec:
+  syncPolicy:
+    preserveResourcesOnDeletion: true
+  generators:
+    - merge:
+        mergeKeys: [server]
+        generators:
+          - clusters:
+              values:
+                addonChart: cronitor
+                addonChartVersion: 0.5.0
+                addonChartRepositoryNamespace: cronitor
+                addonChartRepository: https://cronitorio.github.io/cronitor-kubernetes/
+              selector:
+                matchExpressions:
+                  - key: akuity.io/argo-cd-cluster-name
+                    operator: NotIn
+                    values: [in-cluster]
+                  - key: enable_cronitor
+                    operator: In
+                    values: ['true']
+  template:
+    metadata:
+      name: addon-{{name}}-{{values.addonChart}}
+    spec:
+      project: addons
+      sources:
+        - repoURL: '{{metadata.annotations.addons_repo_url}}'
+          targetRevision: '{{metadata.annotations.addons_repo_revision}}'
+          ref: values
+        - chart: '{{values.addonChart}}'
+          repoURL: '{{values.addonChartRepository}}'
+          targetRevision: '{{values.addonChartVersion}}'
+          helm:
+            releaseName: '{{values.addonChart}}'
+            ignoreMissingValueFiles: true
+            valueFiles:
+              - $values/{{metadata.annotations.addons_repo_basepath}}environments/default/addons/{{values.addonChart}}/values.yaml
+              - $values/{{metadata.annotations.addons_repo_basepath}}environments/{{metadata.labels.environment}}/addons/{{values.addonChart}}/values.yaml
+              - $values/{{metadata.annotations.addons_repo_basepath}}environments/clusters/{{name}}/addons/{{values.addonChart}}/values.yaml
+      destination:
+        namespace: '{{values.addonChartRepositoryNamespace}}'
+        name: '{{name}}'
+      syncPolicy:
+        automated:
+          prune: false
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true  # Big CRDs.

--- a/environments/default/addons/cronitor/values.yaml
+++ b/environments/default/addons/cronitor/values.yaml
@@ -1,0 +1,3 @@
+credentials:
+  secretName: cronitor-secret
+  secretKey: CRONITOR_API_KEY


### PR DESCRIPTION
Cronitor is a monitoring site which, among other things, monitors cronjobs.