### PR TITLE
DEVOPS-2460 karpenter errors

### DIFF
--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
@@ -15,7 +15,7 @@ spec:
                 addonChart: karpenter
                 addonChartReleaseName: karpenter
                 addonChartRepositoryNamespace: karpenter
-                addonChartVersion: v1.0.0
+                addonChartVersion: 1.0.1
                 # using oci repostory already configure in argocd
                 # argocd repo add public.ecr.aws --type helm --name aws-public-ecr --enable-oci
                 addonChartRepository: public.ecr.aws
@@ -32,13 +32,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: v1.0.0
+                addonChartVersion: 1.0.1
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: v1.0.0
+                addonChartVersion: 1.0.1
   template:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}


### PR DESCRIPTION
ArgoCD is unable to install karpenter because it can't find the helm chart. Looking at public.erc.aws, I see they dropped the `v` prefix on the version numbers.

I also noticed a 1.0.1, so we might as well use that.