### PR TITLE
DEVOPS-2460 fix cluster-name error

### DIFF
--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
@@ -60,9 +60,8 @@ spec:
               - $values/{{metadata.annotations.addons_repo_basepath}}clusters/{{name}}/addons/{{values.addonChart}}/values.yaml
             values: |
               settings:
-                aws:
-                  clusterName: {{metadata.annotations.aws_cluster_name}}
-                  interruptionQueue: {{metadata.annotations.karpenter_sqs_queue_name}}
+                clusterName: {{metadata.annotations.aws_cluster_name}}
+                interruptionQueue: {{metadata.annotations.karpenter_sqs_queue_name}}
               serviceAccount:
                 name: {{metadata.annotations.karpenter_service_account}}
                 annotations:


### PR DESCRIPTION
I'm doing this based on this comment in a Github issue:

https://github.com/aws/karpenter-provider-aws/issues/5340#issuecomment-1956432089