### PR TITLE
DEVOPS-2487 upgrade external-dns version

### DIFF
--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-external-dns-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-external-dns-appset.yaml
@@ -15,7 +15,7 @@ spec:
               values:
                 addonChart: external-dns
                 # anything not staging or prod use this version
-                addonChartVersion: 1.14.3
+                addonChartVersion: 1.14.5
                 addonChartRepository: https://kubernetes-sigs.github.io/external-dns
               selector:
                 matchExpressions:
@@ -30,13 +30,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 1.14.3
+                addonChartVersion: 1.14.5
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 1.14.3
+                addonChartVersion: 1.14.5
   template:
     metadata:
       name: 'addon-{{.name}}-{{.values.addonChart}}'


### PR DESCRIPTION
The latest available version, `1.14.5`, does not exit with an error code when it fails with an `InvalidChangeBatch` error. Since this prevents a CrashLoopBackoff situation, it is preferred behavior.