### PR TITLE
DEVOPS-2926 fix history and rollback

### DIFF
--- a/environments/default/addons/argo-cd/values.yaml
+++ b/environments/default/addons/argo-cd/values.yaml
@@ -98,7 +98,7 @@ configs:
       p, role:dev, exec, create, default/*, allow
       p, role:dev, certificates, get, default/*, allow
       p, role:dev, clusters, get, default/*, allow
-      p, role:dev, repositories, get, default/*, allow
+      p, role:dev, repositories, get, *, allow
       p, role:dev, projects, get, default/*, allow
       p, role:dev, accounts, get, default/*, allow
       p, role:dev, gpgkeys, get, default/*, allow


### PR DESCRIPTION
The "History and Rollback" button was not working for non-admin users. Part of the error said:
```
Unable to load data: permission denied: repositories, get,
```

Turns out, the `default/*` scope was incorrect for the `repositories` resource.