### PR TITLE
DEVOPS-3222 update ingress-nginx

### DIFF
--- a/bootstrap/control-plane/addons/oss/addons-ingress-nginx-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-ingress-nginx-appset.yaml
@@ -14,8 +14,9 @@ spec:
           - clusters:
               values:
                 addonChart: ingress-nginx
-                # anything not staging or prod use this version
-                addonChartVersion: 4.10.0
+                # https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx
+                # helm version 4.12.1, app version 1.12.1
+                addonChartVersion: 4.12.1
                 addonChartRepository: https://kubernetes.github.io/ingress-nginx
               selector:
                 matchExpressions:
@@ -30,13 +31,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 4.10.0
+                addonChartVersion: 4.12.1
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 4.10.0
+                addonChartVersion: 4.12.1
   template:
     metadata:
       name: addon-{{.name}}-{{.values.addonChart}}


### PR DESCRIPTION
AWS warned us of some CVEs related to the version of ingress-nginx we're running. This will remediate those.