### PR TITLE
Upgrade KEDA to version 2.15.2

### DIFF
--- a/bootstrap/control-plane/addons/oss/addons-keda-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-keda-appset.yaml
@@ -14,7 +14,7 @@ spec:
               values:
                 addonChart: keda
                 # anything not staging or prod use this version
-                addonChartVersion: 2.14.2
+                addonChartVersion: 2.15.2
                 addonChartRepository: https://kedacore.github.io/charts
               selector:
                 matchExpressions:
@@ -29,13 +29,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 2.14.2
+                addonChartVersion: 2.15.2
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 2.14.2
+                addonChartVersion: 2.15.2
   template:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}


### PR DESCRIPTION
## Summary
Upgrades KEDA addon from version 2.14.x to 2.15.2 across all environments to address missing RBAC permissions.

## Changes
- **provi-eks-control-plane**: Updated `addonChartVersion` from 2.14.2 to 2.15.2 in `addons-keda-appset.yaml`
- **provi-eks-workloads**: Updated `targetRevision` from 2.14.0 to 2.15.2 in both prod and non-prod KEDA templates

## Why This Change is Needed
Version 2.15.2 includes a critical RBAC fix that adds the `get` permission for Secrets to the KEDA operator's minimal RBAC configuration. This is essential for KEDA to properly function when it needs to access Kubernetes Secrets.

## Reference
- GitHub commit: https://github.com/kedacore/charts/commit/d7ba882ae44d98ac466c5829abbe7f10e37e8ba9
- KEDA 2.15.2 release notes: https://github.com/kedacore/charts/releases/tag/keda-2.15.2

