### PR TITLE
INFRASEC-4064 Adds community-charts helm repo

### DIFF
--- a/environments/default/addons/argo-cd/values.yaml
+++ b/environments/default/addons/argo-cd/values.yaml
@@ -84,6 +84,10 @@ configs:
       url: https://cronitorio.github.io/cronitor-kubernetes
       name: cronitor
       type: helm
+    community-charts:
+      url: https://community-charts.github.io/helm-charts
+      name: community-charts
+      type: helm
 
   rbac:
     policy.default: "role:dev"


### PR DESCRIPTION
This repo needs to be added to the ArgoCD repos in order for the mflow Application to be able to use it.